### PR TITLE
Update version to include node exporter for telemetry

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sonic-telemetry (0.1) UNRELEASED; urgency=medium
+sonic-telemetry (0.2) UNRELEASED; urgency=medium
 
   * Initial release.
 


### PR DESCRIPTION
Change version 0.1 to 0.2 to include node exporter for telemetry